### PR TITLE
Add config.yaml.example and expand README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,50 @@ A collection of tools for analysing Reddit data from the AusReddit collection, d
 | `LDA_over_time.py` | LDA topic modelling over time |
 | `NLP_over_time.py` | Basic NLP analysis |
 | `topic_window.py` | BERTopic and BERTopic with time windows |
-| `config.yaml` | Configuration file for options, hyperparameters, and API keys (see setup below) |
+| `config.yaml.example` | Template configuration file — copy this to `config.yaml` and fill in your credentials |
+
+---
 
 ## Setup
 
-Copy `config.yaml` and fill in your credentials. The file is excluded from version control via `.gitignore` to prevent accidental secret exposure.
+### 1. Copy the example config
+
+```bash
+cp config.yaml.example config.yaml
+```
+
+`config.yaml` is excluded from version control via `.gitignore` so your credentials will never be accidentally committed.
+
+### 2. Fill in your credentials
+
+Open `config.yaml` and replace each placeholder with your real values:
 
 ```yaml
+reddit:
+  client_id: 'your_client_id'         # from https://www.reddit.com/prefs/apps
+  client_secret: 'your_client_secret'
+  redirect_uri: 'your_redirect_uri'
+  user_agent: 'your_user_agent'
+
 ausreddit:
-  api_key: 'your_api_key'
+  api_key: 'your_api_key'             # AusReddit collection API key
+
+open_ai:
+  api_key: 'your_openai_api_key'      # optional, only needed for OpenAI-backed tools
 
 far_bot:
-  google_api_key: 'your_google_api_key'
+  google_api_key: 'your_google_api_key'         # Google AI Studio API key
   langsmith_tracing: 'true'
   langsmith_endpoint: 'https://api.smith.langchain.com'
-  langsmith_api_key: 'your_langsmith_api_key'
-  langsmith_project: 'your_langsmith_project'
+  langsmith_api_key: 'your_langsmith_api_key'   # LangSmith API key
+  langsmith_project: 'your_langsmith_project'   # LangSmith project name
 ```
+
+The `umap`, `pca`, `tsvd`, `hdbscan`, `kmeans`, and `bertopic` sections contain hyperparameters that can be tuned — the defaults in `config.yaml.example` are a good starting point.
+
+Set `hardware: CPU` if you do not have a GPU available.
+
+---
 
 ## Feasibility Assessment Bot (`far_bot.py`)
 
@@ -56,3 +83,9 @@ The `--save` / `save=True` flag writes the report (`.md`) and charts (`.png`) to
 ### Date formats
 
 `--start` and `--end` accept `yyyy-mm-dd` or `dd/mm/yyyy`.
+
+### Output
+
+- A feasibility report printed to the terminal (and optionally saved as a `.md` file)
+- A bar chart of submission counts over time (`submission_frequency.png`)
+- A line chart of ngram usage percentages over time (`ngram_volume.png`)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,50 @@
+umap:
+  n_components: 5
+  n_neighbors: 20
+  min_dist: 0.0
+  random_state: 42
+
+pca:
+  n_components: 5
+  random_state: 42
+
+tsvd:
+  n_components: 5
+  random_state: 42
+
+hdbscan:
+  min_cluster_size: 3
+  min_samples: 2
+  gen_min_span_tree: True
+  prediction_data: True
+
+kmeans:
+  n_clusters: 100
+  random_state: 42
+
+bertopic:
+  calculate_probabilities: False
+  verbose: True
+  min_topic_size: 10
+  min_similarity: 0.7
+
+hardware: GPU  # set to CPU if no GPU is available
+
+reddit:
+  client_id: 'your_client_id'
+  client_secret: 'your_client_secret'
+  redirect_uri: 'your_redirect_uri'
+  user_agent: 'your_user_agent'
+
+ausreddit:
+  api_key: 'your_api_key'
+
+open_ai:
+  api_key: 'your_openai_api_key'
+
+far_bot:
+  google_api_key: 'your_google_api_key'
+  langsmith_tracing: 'true'
+  langsmith_endpoint: 'https://api.smith.langchain.com'
+  langsmith_api_key: 'your_langsmith_api_key'
+  langsmith_project: 'your_langsmith_project'


### PR DESCRIPTION
config.yaml.example gives researchers/students a complete template to copy to config.yaml (which is gitignored). Includes all sections: umap, pca, tsvd, hdbscan, kmeans, bertopic, hardware, reddit, ausreddit, open_ai, and far_bot — all with placeholder values.

README updated with step-by-step setup instructions and expanded far_bot usage and output documentation.

https://claude.ai/code/session_01EvNxjGwG8NWdxpsUAB2oWu