### PR TITLE
Update trees.ipynb for new tree_graph_and_adj_list signature

### DIFF
--- a/trees.ipynb
+++ b/trees.ipynb
@@ -41,11 +41,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# required imports\n",
-    "from reddit_topic_trees import Reddit_trees\n",
-    "import pandas as pd"
-   ]
+   "source": "# required imports\nfrom reddit_topic_trees import Reddit_trees\nfrom ausreddit_metrics import AusredditMetrics\nimport pandas as pd"
   },
   {
    "cell_type": "markdown",
@@ -61,17 +57,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "#load the data from a csv file\n",
-    "\n",
-    "data = pd.read_csv('data/snake_comments.csv')\n",
-    "\n",
-    "print(len(data['id']))\n",
-    "\n",
-    "#check the data\n",
-    "\n",
-    "print(data.head(10))"
-   ]
+   "source": "# load comments and submissions\ndata = pd.read_csv('data/snake_comments.csv')\nsubmissions = pd.read_csv('data/snake_submissions.csv')\n\nprint(len(data['id']))\n\n# check the data\nprint(data.head(10))"
   },
   {
    "cell_type": "markdown",
@@ -124,10 +110,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "#build the graph object and the adjacency list\n",
-    "G_tree, adj_list = reddit_workflow.tree_graph_and_adj_list(data, incl_topic = False)\n"
-   ]
+   "source": "# build the graph object and the adjacency list\nG_tree, adj_list = reddit_workflow.tree_graph_and_adj_list(data, submissions, incl_topic=False)"
   },
   {
    "cell_type": "markdown",
@@ -141,19 +124,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# plot a basic graph of a single comment tree\n",
-    "\n",
-    "#make a slice of our orginal data by conversation id (link_id)\n",
-    "\n",
-    "data_slice = data[data['link_id'] == 't3_1f1jeir']\n",
-    "\n",
-    "#build the graph object and the adjacency list\n",
-    "\n",
-    "G_tree_slice, adj_list_slice = reddit_workflow.tree_graph_and_adj_list(data_slice, incl_topic = False)\n",
-    "\n",
-    "reddit_workflow.plot_kk_graph(G_tree_slice, 'kk_graph')"
-   ]
+   "source": "# plot a basic graph of a single comment tree\n\n# slice comments and submissions to a single conversation\ndata_slice = data[data['link_id'] == 't3_1f1jeir']\nsubmissions_slice = submissions[submissions['id'] == '1f1jeir']\n\n# build the graph object and the adjacency list\nG_tree_slice, adj_list_slice = reddit_workflow.tree_graph_and_adj_list(data_slice, submissions_slice, incl_topic=False)\n\nreddit_workflow.plot_kk_graph(G_tree_slice, 'kk_graph')"
   },
   {
    "cell_type": "markdown",
@@ -290,18 +261,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "We should pass the combined dataframe for the sake of completeness of the graphs. This way the orginal submission and the commetns are in the same topic space. However the \"incl_topic\" flag needs to be set to True in the function arguments."
-   ]
+   "source": "We pass the separately-modelled comments and submissions dataframes to keep them in the same topic space while giving `tree_graph_and_adj_list` the two distinct inputs it needs. The `combined_df` returned by `topic_model_combined` is split back into its constituent parts using the original submission IDs."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "G_combined, adj_list_combined = reddit_workflow.tree_graph_and_adj_list(combined_df, incl_topic = True)"
-   ]
+   "source": "# split combined_df back into submissions and comments using original submission IDs\ncomments_modeled = combined_df[combined_df['id'].isin(comments['id'])]\nsubmissions_modeled = combined_df[combined_df['id'].isin(submissions['id'])]\n\nG_combined, adj_list_combined = reddit_workflow.tree_graph_and_adj_list(comments_modeled, submissions_modeled, incl_topic=True)"
   },
   {
    "cell_type": "markdown",
@@ -445,12 +412,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "G_combined_lda, adj_list_combined_lda = reddit_workflow.tree_graph_and_adj_list(combined_lda, incl_topic = True)"
-   ]
+   "source": "# split combined_lda by the 'source' column added by lda_combined()\ncomments_lda_only = combined_lda[combined_lda['source'] == 'comment']\nsubmissions_lda_only = combined_lda[combined_lda['source'] == 'submission']\n\nG_combined_lda, adj_list_combined_lda = reddit_workflow.tree_graph_and_adj_list(comments_lda_only, submissions_lda_only, incl_topic=True)"
   },
   {
    "cell_type": "markdown",
@@ -506,7 +471,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "emotion_cols = ['anger', 'anticipation', 'disgust', 'fear', 'joy', 'sadness', 'surprise', 'trust']\nG_emo, adj_list_emo = reddit_workflow.tree_graph_and_adj_list(comments_emo, incl_topic=False, extra_node_cols=emotion_cols)"
+   "source": "emotion_cols = ['anger', 'anticipation', 'disgust', 'fear', 'joy', 'sadness', 'surprise', 'trust']\nG_emo, adj_list_emo = reddit_workflow.tree_graph_and_adj_list(comments_emo, submissions, incl_topic=False, extra_node_cols=emotion_cols)"
   },
   {
    "cell_type": "code",
@@ -525,6 +490,25 @@
    "source": [
     "reddit_workflow.save_graph(G_emo, 'reddit_emo_tree.graphml')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "source": "# save the metrics to a csv file\nmetrics_df.to_csv('reddit_metrics.csv')",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# compute per-submission metrics from the full graph\nmetrics = AusredditMetrics()\nmetrics_df = metrics.analyze_conversation_graphs(G_tree)\n\nprint(metrics_df)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "<div align=\"center\">\n    <h1><strong>Conversation Metrics</strong></h1>\n</div>\n\n`AusredditMetrics` computes structural and time-based metrics for each submission tree in a graph. Pass any graph built by `tree_graph_and_adj_list()` — it will split the graph into per-submission components and return one row of metrics per submission.\n\nMetrics include:\n\n- **num_comments** — number of comment nodes (excludes the submission root)\n- **longest_path_length** — depth of the deepest reply chain\n- **average_path_length** — mean depth across all nodes\n- **num_branches** — nodes where more than one reply was made\n- **num_endpoints** — leaf nodes (comments with no further replies)\n- **total_duration** — time from submission to last comment (HH:MM:SS)\n- **shortest / longest / average_response_time** — reply time statistics (HH:MM:SS)",
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- All five calls to `tree_graph_and_adj_list` updated to pass `comments_df` and `submissions_df` as separate arguments, matching the new signature introduced in PR #18
- `snake_submissions.csv` is now loaded alongside comments at the start of the notebook so `submissions` is in scope throughout all workflows
- BERTopic combined workflow splits `combined_df` back into comments/submissions by matching on the original submission IDs before passing to the graph builder
- LDA combined workflow splits `combined_lda` using the `'source'` column added by `lda_combined()`
- Adds a **Conversation Metrics** section at the end demonstrating `AusredditMetrics.analyze_conversation_graphs()` with a save step

## Test plan

- [ ] Run the "Dataframe by Itself" section end-to-end with `snake_comments.csv` and `snake_submissions.csv`
- [ ] Confirm the sliced graph (`t3_1f1jeir`) plots correctly with the submission as root
- [ ] Run the BERTopic and LDA combined workflows and verify graphs have one component per submission
- [ ] Run the Emotion workflow and confirm emotion node attributes are present
- [ ] Run the Metrics section and confirm the output DataFrame is indexed by submission ID

https://claude.ai/code/session_014TYUQuDvPAGKkNku8cZtSG
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014TYUQuDvPAGKkNku8cZtSG)_